### PR TITLE
fix: harden reputation and incident ingestion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,14 @@ default_stages: [pre-commit]
 
 # This is a template for connector pre-commit hooks
 repos:
+  - repo: local
+    hooks:
+      - id: threatstream-security-tests
+        name: ThreatStream security regression tests
+        entry: python3 -m unittest discover -s tests -v
+        language: system
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,5 @@
 **Unreleased**
+
+* Make exact-value reputation searches use an encoded exact filter and discard mismatched intelligence records.
+* Fail reputation actions when requested external-reference enrichment fails and preserve well-formed result rows.
+* Reuse only connector-tracked incident containers and reject unrecognized or duplicate container matches.

--- a/tests/test_threatstream_security.py
+++ b/tests/test_threatstream_security.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import importlib
+import json as stdlib_json
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _install_import_stubs():
+    phantom = types.ModuleType("phantom")
+    phantom.__path__ = []
+    phantom_app = types.ModuleType("phantom.app")
+    phantom_app.APP_SUCCESS = True
+    phantom_app.APP_ERROR = False
+    phantom_app.is_fail = lambda value: not value
+    phantom.app = phantom_app
+    phantom_rules = types.ModuleType("phantom.rules")
+    phantom.rules = phantom_rules
+    phantom_action_result = types.ModuleType("phantom.action_result")
+    phantom_action_result.ActionResult = object
+    phantom_base_connector = types.ModuleType("phantom.base_connector")
+    phantom_base_connector.BaseConnector = object
+    phantom_vault = types.ModuleType("phantom.vault")
+    phantom_vault.Vault = object
+
+    dateutil = types.ModuleType("dateutil")
+    dateutil.__path__ = []
+    dateutil_parser = types.ModuleType("dateutil.parser")
+    dateutil_tz = types.ModuleType("dateutil.tz")
+    dateutil.parser = dateutil_parser
+    dateutil.tz = dateutil_tz
+
+    simplejson = types.ModuleType("simplejson")
+    simplejson.dumps = stdlib_json.dumps
+    simplejson.loads = stdlib_json.loads
+    bs4 = types.ModuleType("bs4")
+    bs4.BeautifulSoup = object
+    bs4.UnicodeDammit = object
+    ipwhois = types.ModuleType("ipwhois")
+    ipwhois.IPWhois = object
+    pytz = types.ModuleType("pytz")
+    requests = types.ModuleType("requests")
+    wizard_whois = types.ModuleType("wizard_whois")
+
+    modules = {
+        "phantom": phantom,
+        "phantom.app": phantom_app,
+        "phantom.rules": phantom_rules,
+        "phantom.action_result": phantom_action_result,
+        "phantom.base_connector": phantom_base_connector,
+        "phantom.vault": phantom_vault,
+        "dateutil": dateutil,
+        "dateutil.parser": dateutil_parser,
+        "dateutil.tz": dateutil_tz,
+        "simplejson": simplejson,
+        "bs4": bs4,
+        "ipwhois": ipwhois,
+        "pytz": pytz,
+        "requests": requests,
+        "wizard_whois": wizard_whois,
+    }
+    for name, module in modules.items():
+        sys.modules.setdefault(name, module)
+
+
+_install_import_stubs()
+connector_module = importlib.import_module("threatstream_connector")
+
+
+class FakeActionResult:
+    def __init__(self):
+        self.data = []
+        self.status = None
+        self.message = ""
+
+    def add_data(self, value):
+        self.data.append(value)
+
+    def get_data(self):
+        return self.data
+
+    def set_status(self, status, message):
+        self.status = status
+        self.message = message
+        return status
+
+    def get_status(self):
+        return self.status
+
+
+class Response:
+    def __init__(self, body):
+        self.body = body
+
+    def json(self):
+        return self.body
+
+
+class ThreatstreamSecurityTests(unittest.TestCase):
+    def connector(self):
+        connector = object.__new__(connector_module.ThreatstreamConnector)
+        connector._state = {}
+        connector.debug_print = mock.Mock()
+        return connector
+
+    def test_exact_lookup_uses_encoded_exact_parameter_and_drops_mismatches(self):
+        connector = self.connector()
+        connector._paginator = mock.Mock(
+            return_value=[
+                {"id": 1, "value": "requested"},
+                {"id": 2, "value": "injected-result"},
+            ]
+        )
+        result = FakeActionResult()
+
+        status = connector._intel_details(result, exact_value="requested", limit=10)
+
+        self.assertTrue(status)
+        self.assertEqual(result.data, [{"id": 1, "value": "requested"}])
+        payload = connector._paginator.call_args.kwargs["payload"]
+        self.assertEqual(payload["value"], "requested")
+        self.assertNotIn("q", payload)
+
+    def test_external_reference_failure_fails_action(self):
+        connector = self.connector()
+        connector._make_rest_call = mock.Mock(return_value=(False, {}))
+        result = FakeActionResult()
+
+        status = connector._external_references("indicator", result)
+
+        self.assertFalse(status)
+        self.assertEqual(result.message, "Error retrieving external references")
+
+    def test_enrichment_updates_existing_row_without_appending_none(self):
+        connector = self.connector()
+        connector._make_rest_call = mock.Mock(return_value=(True, {"insights": ["one"]}))
+        result = FakeActionResult()
+        result.add_data({"value": "indicator"})
+
+        status = connector._insight("indicator", "domain", result)
+
+        self.assertTrue(status)
+        self.assertEqual(result.data, [{"value": "indicator", "insights": ["one"]}])
+
+    def test_untracked_container_match_is_rejected(self):
+        connector = self.connector()
+        connector.get_phantom_base_url = mock.Mock(return_value="https://soar/")
+        connector.get_asset_id = mock.Mock(return_value=7)
+
+        with mock.patch.object(
+            connector_module.requests,
+            "get",
+            return_value=Response({"count": 1, "data": [{"id": 99, "name": "12-test"}]}),
+            create=True,
+        ):
+            status, container_id = connector._check_and_update_container_already_exists(12, "test")
+
+        self.assertFalse(status)
+        self.assertIsNone(container_id)
+
+    def test_only_state_tracked_container_is_reused(self):
+        connector = self.connector()
+        connector._state = {"incident_container_ids": {"12": 99}}
+        connector.get_phantom_base_url = mock.Mock(return_value="https://soar/")
+        connector.get_asset_id = mock.Mock(return_value=7)
+
+        with mock.patch.object(
+            connector_module.requests,
+            "get",
+            return_value=Response({"count": 1, "data": [{"id": 99, "name": "12-test"}]}),
+            create=True,
+        ):
+            status, container_id = connector._check_and_update_container_already_exists(12, "test")
+
+        self.assertTrue(status)
+        self.assertEqual(container_id, 99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/threatstream_connector.py
+++ b/threatstream_connector.py
@@ -432,15 +432,24 @@ class ThreatstreamConnector(BaseConnector):
 
         return payload
 
-    def _intel_details(self, action_result, q=None, value=None, limit=None, extend_source=False):
+    def _intel_details(self, action_result, q=None, value=None, exact_value=None, limit=None, extend_source=False):
         """Use the intelligence endpoint to get general details"""
 
-        payload = self._generate_payload(extend_source=extend_source, order_by="-created_ts", q=q, value=value, limit=limit)
+        payload = self._generate_payload(
+            extend_source=extend_source,
+            order_by="-created_ts",
+            q=q,
+            value=exact_value if exact_value is not None else value,
+            limit=limit,
+        )
 
         intel_details = self._paginator(ENDPOINT_INTELLIGENCE, action_result, payload=payload, limit=limit)
 
         if intel_details is None:
             return action_result.get_status()
+
+        if exact_value is not None:
+            intel_details = [detail for detail in intel_details if detail.get("value") == exact_value]
 
         for detail in intel_details:
             action_result.add_data(detail)
@@ -462,7 +471,7 @@ class ThreatstreamConnector(BaseConnector):
         # action_result.add_data({'pdns': resp_json['results']})
         # self._data_dict['pdns'] = resp_json['results']
         if action_result.get_data():
-            action_result.add_data(action_result.get_data()[0].update({"pdns": resp_json["results"]}))
+            action_result.get_data()[0].update({"pdns": resp_json["results"]})
         else:
             action_result.add_data({"pdns": resp_json["results"]})
         return action_result.set_status(phantom.APP_SUCCESS, "Retrieved")
@@ -479,7 +488,7 @@ class ThreatstreamConnector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, "Error retrieving insights")
 
         if action_result.get_data():
-            action_result.add_data(action_result.get_data()[0].update({"insights": resp_json["insights"]}))
+            action_result.get_data()[0].update({"insights": resp_json["insights"]})
         else:
             action_result.add_data({"insights": resp_json["insights"]})
         return action_result.set_status(phantom.APP_SUCCESS, "Retrieved")
@@ -491,10 +500,10 @@ class ThreatstreamConnector(BaseConnector):
         ret_val, resp_json = self._make_rest_call(action_result, ext_ref, payload)
 
         if phantom.is_fail(ret_val):
-            return action_result.set_status(phantom.APP_SUCCESS, "Error retrieving external references")
+            return action_result.set_status(phantom.APP_ERROR, "Error retrieving external references")
 
         if action_result.get_data():
-            action_result.add_data(action_result.get_data()[0].update({"external_references": resp_json}))
+            action_result.get_data()[0].update({"external_references": resp_json})
         else:
             action_result.add_data({"external_references": resp_json})
         return action_result.set_status(phantom.APP_SUCCESS, "Retrieved")
@@ -588,7 +597,7 @@ class ThreatstreamConnector(BaseConnector):
         self.debug_print(f"Retrieving ip domain with {param}")
 
         if search_exact_value:
-            ret_val = self._intel_details(action_result, q=f"(value={value})", limit=limit, extend_source=extend_source)
+            ret_val = self._intel_details(action_result, exact_value=value, limit=limit, extend_source=extend_source)
         else:
             ret_val = self._intel_details(action_result, value=value, limit=limit, extend_source=extend_source)
 
@@ -619,7 +628,7 @@ class ThreatstreamConnector(BaseConnector):
         """Retrieve all the information needed for email or md5 hashes"""
 
         if search_exact_value:
-            ret_val = self._intel_details(action_result, q=f"(value={value})", limit=limit, extend_source=extend_source)
+            ret_val = self._intel_details(action_result, exact_value=value, limit=limit, extend_source=extend_source)
         else:
             ret_val = self._intel_details(action_result, value=value, limit=limit, extend_source=extend_source)
         if not ret_val:
@@ -734,7 +743,7 @@ class ThreatstreamConnector(BaseConnector):
             return action_result.get_status()
 
         if search_exact_value:
-            ret_val = self._intel_details(action_result, q=f"(value={value})", limit=limit, extend_source=extend_source)
+            ret_val = self._intel_details(action_result, exact_value=value, limit=limit, extend_source=extend_source)
         else:
             ret_val = self._intel_details(action_result, value=value, limit=limit, extend_source=extend_source)
         if not ret_val:
@@ -2109,6 +2118,8 @@ class ThreatstreamConnector(BaseConnector):
 
     def _check_and_update_container_already_exists(self, incident_id, incident_name, verify=False):
         url = f'{self.get_phantom_base_url()}rest/container?_filter_source_data_identifier="{incident_id}"&_filter_asset={self.get_asset_id()}'
+        tracked_containers = self._state.setdefault("incident_container_ids", {})
+        tracked_container_id = tracked_containers.get(str(incident_id))
 
         try:
             r = requests.get(url, verify=verify, timeout=DEFAULT_TIMEOUT)
@@ -2116,21 +2127,32 @@ class ThreatstreamConnector(BaseConnector):
         except Exception as e:
             error_message = self._get_error_message_from_exception(e)
             self.debug_print(f"Unable to query ThreatStream incident container: {error_message}")
-            return None
+            return phantom.APP_ERROR, None
 
         if resp_json.get("count", 0) <= 0:
+            if tracked_container_id is not None:
+                self.debug_print(f"Tracked container {tracked_container_id} for incident {incident_id} no longer exists")
+                return phantom.APP_ERROR, None
             self.debug_print("No container matched")
-            return None
+            return phantom.APP_SUCCESS, None
 
-        try:
-            container_id = resp_json.get("data", [])[0]["id"]
-        except Exception as e:
-            self.debug_print("Container results are not proper: ", e)
-            return None
+        matching_containers = resp_json.get("data", [])
+        container = next(
+            (item for item in matching_containers if str(item.get("id")) == str(tracked_container_id)),
+            None,
+        )
+        if tracked_container_id is None or container is None:
+            self.debug_print(
+                f"Refusing untracked container match for ThreatStream incident {incident_id}; "
+                "the source data identifier and asset fields do not prove connector ownership"
+            )
+            return phantom.APP_ERROR, None
+
+        container_id = container["id"]
 
         # If the container exists and the name of the incident has been updated,
         # update the name of the container as well to stay in sync with the UI of ThreatStream
-        if container_id and (resp_json.get("data", [])[0]["name"] != f"{incident_id}-{incident_name}"):
+        if container_id and (container.get("name") != f"{incident_id}-{incident_name}"):
             url = f"{self.get_phantom_base_url()}rest/container/{container_id}"
             try:
                 data = {"name": f"{incident_id}-{incident_name}"}
@@ -2139,7 +2161,7 @@ class ThreatstreamConnector(BaseConnector):
             except Exception as e:
                 error_message = self._get_error_message_from_exception(e)
                 self.debug_print(f"Unable to update the name of the ThreatStream incident container: {error_message}")
-                return container_id
+                return phantom.APP_SUCCESS, container_id
 
             if not resp_json.get("success"):
                 self.debug_print(
@@ -2147,9 +2169,9 @@ class ThreatstreamConnector(BaseConnector):
                     {incident_name} of the incident ID: {incident_id}"
                 )
                 self.debug_print(f"Response of the container updation is: {resp_json!s}")
-                return container_id
+                return phantom.APP_SUCCESS, container_id
 
-        return container_id
+        return phantom.APP_SUCCESS, container_id
 
     def _handle_on_poll(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
@@ -2320,7 +2342,13 @@ class ThreatstreamConnector(BaseConnector):
             artifact["cef_types"] = {"id": ["threatstream incident id"], "organization_id": ["threatstream organization id"]}
             artifacts_list.append(artifact)
 
-            existing_container_id = self._check_and_update_container_already_exists(resp_json.get("id"), resp_json.get("name"))
+            incident_id = resp_json.get("id")
+            ret_val, existing_container_id = self._check_and_update_container_already_exists(incident_id, resp_json.get("name"))
+            if phantom.is_fail(ret_val):
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Refusing to ingest ThreatStream incident {incident_id} into an untracked container",
+                )
 
             self.debug_print("Saving container and adding artifacts for the incident ID: {}".format(resp_json.get("id")))
 
@@ -2343,7 +2371,15 @@ class ThreatstreamConnector(BaseConnector):
                     self.debug_print(message)
                     return action_result.set_status(phantom.APP_ERROR, "Failed creating container")
 
+                if "duplicate" in str(message).lower():
+                    self.debug_print(f"Refusing duplicate container returned for ThreatStream incident {incident_id}: {message}")
+                    return action_result.set_status(
+                        phantom.APP_ERROR,
+                        f"Refusing to ingest ThreatStream incident {incident_id} into an untracked duplicate container",
+                    )
+
                 existing_container_id = container_id
+                self._state.setdefault("incident_container_ids", {})[str(incident_id)] = container_id
 
             # Add the artifacts_list to either the created or
             # the existing container with ID in existing_container_id


### PR DESCRIPTION
## Summary

- send exact reputation lookups through the encoded value parameter and discard mismatched results
- fail requested external-reference enrichment closed and avoid appending null result rows
- reuse only state-tracked incident containers, rejecting unrecognized and duplicate matches
- run focused security regression tests in pre-commit

## Tracking

- ESPM-5228
- PAPP-38304
- PSAAS-32586
- PSAAS-32655
- PSAAS-32864

## Validation

- `python3.13 -m unittest discover -s tests -v` (5 passed)
- fresh public-PyPI `pre-commit run --all-files` (all hooks passed)

Authored and posted by Codex.

## Tracking

- PAPP: PAPP-38304
- PSAAS: PSAAS-32586, PSAAS-32655, PSAAS-32864
- Written by Codex.